### PR TITLE
Fix issue #17: open() throws exception.

### DIFF
--- a/create_driver/src/create_driver/create_driver.py
+++ b/create_driver/src/create_driver/create_driver.py
@@ -210,7 +210,6 @@ class SerialCommandInterface(object):
   """
   def __init__(self, tty, baudrate):
     self.ser = serial.Serial(tty, baudrate=baudrate, timeout=SERIAL_TIMEOUT)
-    self.ser.open()
     self.wake()
     self.opcodes = {}
 

--- a/create_node/nodes/turtlebot_node.py
+++ b/create_node/nodes/turtlebot_node.py
@@ -117,7 +117,7 @@ class TurtlebotNode(object):
                 self.robot.start(self.port, robot_types.ROBOT_TYPES[self.robot_type].baudrate)
                 break
             except serial.serialutil.SerialException as ex:
-                msg = "Failed to open port %s.  Please make sure the Create cable is plugged into the computer. \n"%(self.port)
+                msg = "Failed to open port %s. Error: %s Please make sure the Create cable is plugged into the computer. \n"%((self.port), ex.message)
                 self._diagnostics.node_status(msg,"error")
                 if log_once:
                     log_once = False


### PR DESCRIPTION
Remove open() to fix double-open exception. Improve error info when an exception on opening serial port happens
