### PR TITLE
Fix extreme slipping of Create base in Gazebo

### DIFF
--- a/create_description/urdf/create_gazebo.urdf.xacro
+++ b/create_description/urdf/create_gazebo.urdf.xacro
@@ -19,32 +19,38 @@
 	  </gazebo>
   
     <gazebo reference="left_wheel_link">
-      <mu1 value="10"/>
-      <mu2 value="10"/>
-      <kp value="100000000.0"/>
-      <kd value="10000.0"/>
-      <fdir1 value="1 0 0"/>
+      <mu1>1.0</mu1>
+      <mu2>1.0</mu2>
+      <kp>1000000.0</kp>
+      <kd>100.0</kd>
+      <minDepth>0.001</minDepth>
+      <maxVel>1.0</maxVel>
     </gazebo>
   
     <gazebo reference="right_wheel_link">
-      <mu1 value="10"/>
-      <mu2 value="10"/>
-      <kp value="100000000.0"/>
-      <kd value="10000.0"/>
-      <fdir1 value="1 0 0"/>
+      <mu1>1.0</mu1>
+      <mu2>1.0</mu2>
+      <kp>1000000.0</kp>
+      <kd>100.0</kd>
+      <minDepth>0.001</minDepth>
+      <maxVel>1.0</maxVel>
     </gazebo>
     <gazebo reference="rear_wheel_link">
-      <mu1 value="0"/>
-      <mu2 value="0"/>
-      <kp value="100000000.0"/>
-      <kd value="10000.0"/>
+      <mu1>0.0</mu1>
+      <mu2>0.0</mu2>
+      <kp>1000000.0</kp>
+      <kd>100.0</kd>
+      <minDepth>0.001</minDepth>
+      <maxVel>1.0</maxVel>
     </gazebo>
   
     <gazebo reference="front_wheel_link">
-      <mu1 value="0"/>
-      <mu2 value="0"/>
-      <kp value="100000000.0"/>
-      <kd value="10000.0"/>
+      <mu1>0.0</mu1>
+      <mu2>0.0</mu2>
+      <kp>1000000.0</kp>
+      <kd>100.0</kd>
+      <minDepth>0.001</minDepth>
+      <maxVel>1.0</maxVel>
     </gazebo>
 	</xacro:macro>
 


### PR DESCRIPTION
The Create base slips extremly in Gazebo using everything installed from current .debs. Without commanding a motion, the robot moves away meters from the starting position within a minute just by sliding over the ground due to bad friction parameters. This pull request changes them so they are the same as on the Kobuki base, making the Create usable in Gazebo again.
