### PR TITLE
Actually use provided configuration

### DIFF
--- a/create_node/src/create_node/gyro.py
+++ b/create_node/src/create_node/gyro.py
@@ -54,8 +54,8 @@ class TurtlebotGyro():
         self.imu_pub_raw = rospy.Publisher('imu/raw', sensor_msgs.msg.Imu)
 
     def reconfigure(self, config, level): 
-        self.gyro_measurement_range = rospy.get_param('~gyro_measurement_range', 150.0) 
-        self.gyro_scale_correction = rospy.get_param('~gyro_scale_correction', 1.35) 
+        self.gyro_measurement_range = config['gyro_measurement_range'] 
+        self.gyro_scale_correction = config['gyro_scale_correction']
         rospy.loginfo('self.gyro_measurement_range %f'%self.gyro_measurement_range) 
         rospy.loginfo('self.gyro_scale_correction %f'%self.gyro_scale_correction) 
 


### PR DESCRIPTION
Now that the gyro configuration is provided with dynamic reconfigure, the code currently is completely ignoring the parameters given to it.  Please merge this quickly to prevent anyone else with a 250 d/s gyro from having a week of hell.
