### PR TITLE
Fix base geometry collision size

### DIFF
--- a/create_description/urdf/create.urdf.xacro
+++ b/create_description/urdf/create.urdf.xacro
@@ -48,7 +48,7 @@
 	    <collision>
 	      <origin xyz="0.0 0.0 0.0308" rpy="0 0 0" />
 	      <geometry>
-	        <cylinder length="0.0611632" radius="0.016495"/>
+	        <cylinder length="0.0611632" radius="0.16495"/>
 	      </geometry>
 	    </collision>
 	  </link>


### PR DESCRIPTION
The base is roughly 16.5cm around; not 16.5mm.

I verified this on my create; it's about 33cm in diameter.
