### PR TITLE
set robot to passive mode on shutdown

### DIFF
--- a/create_node/nodes/turtlebot_node.py
+++ b/create_node/nodes/turtlebot_node.py
@@ -509,8 +509,17 @@ class TurtlebotNode(object):
 def connected_file():
     return os.path.join(rospkg.get_ros_home(), 'turtlebot-connected')
 
+def on_shutdown():
+    global c
+    rospy.loginfo("setting robot to passive mode on shutdown")
+    c.robot.passive()
+
 def turtlebot_main(argv):
+    global c
     c = TurtlebotNode()
+
+    rospy.on_shutdown(on_shutdown)
+
     while not rospy.is_shutdown():
         try:
             # This sleep throttles reconnecting of the driver.  It


### PR DESCRIPTION
on shutdown, turtlebot stays in full mode, thus consuming battery, and refusing to get charged. This fix sets the robot to passive mode on shutdown which solves both mentioned issues
