### PR TITLE
Add check code for sensor state packet

### DIFF
--- a/create_node/nodes/turtlebot_node.py
+++ b/create_node/nodes/turtlebot_node.py
@@ -320,6 +320,14 @@ class TurtlebotNode(object):
         if self._gyro:
             self._gyro.update_calibration(sensor_state)
 
+        # Check if the sensor state is valid. If it is invalid, raise Error and ignore the packet 
+        if abs(sensor_state.distance) > 1.0 or abs(sensor_state.angle) > 1.0:
+            rospy.logwarn("Distance, angle displacement too big, invalid readings from robot. Distance: %.2f, Angle: %.2f" % (sensor_state.distance, sensor_state.angle))
+            raise DriverError
+        if sensor_state.oi_mode not in (1, 2, 3):
+            rospy.logwarn("Invalid OI Mode: %d" % sensor_state.oi_mode)
+            raise DriverError
+
     def spin(self):
 
         # state


### PR DESCRIPTION
The current code check the health of the sensor packet just before it is used. And if it is not valid, it raises exception, but it cause the system reset and lost connection to Roomba (or Create) for seconds. As the result, the robot can be out of control for that duration. 

This PR is raise DriverError which the code just ignored the current sensor packet if the sensor information is invalid. I confirmed it works and ease the problem I reported on #39 .
