### PR TITLE
improved error handling to alert user that sci connection issues can …

### DIFF
--- a/create_node/nodes/turtlebot_node.py
+++ b/create_node/nodes/turtlebot_node.py
@@ -237,7 +237,7 @@ class TurtlebotNode(object):
 
     def set_operation_mode(self,req):
         if not self.robot.sci:
-            rospy.logwarn("Create : robot not connected yet, sci not available")
+            rospy.logwarn("Create : robot not connected yet, sci not available. Check if cable is connected. Incorrect TURTLEBOT_BASE environment variable causing the wrong baudrate to be used is another possible cause.")
             return SetTurtlebotModeResponse(False)
 
         self.operate_mode = req.mode
@@ -309,7 +309,7 @@ class TurtlebotNode(object):
 
     def set_digital_outputs(self,req):
         if not self.robot.sci:
-            raise Exception("Robot not connected, SCI not available")
+            raise Exception("Robot not connected, SCI not available. Incorrect TURTLEBOT_BASE environment variable causing the wrong baudrate to be used is another possible cause.")
             
         outputs = [req.digital_out_0,req.digital_out_1, req.digital_out_2]
         self._set_digital_outputs(outputs)

--- a/create_node/nodes/turtlebot_node.py
+++ b/create_node/nodes/turtlebot_node.py
@@ -117,7 +117,7 @@ class TurtlebotNode(object):
                 self.robot.start(self.port, robot_types.ROBOT_TYPES[self.robot_type].baudrate)
                 break
             except serial.serialutil.SerialException as ex:
-                msg = "Failed to open port %s. Error: %s Please make sure the Create cable is plugged into the computer. \n"%((self.port), ex.message)
+                msg = "Failed to open port %s. Error: %s Please make sure the Create cable is plugged into the computer. Ensure environment variable is set to TURTLEBOT_BASE=create for Create 1 base, TURTLEBOT_BASE=roomba for Create 2.\n"%((self.port), ex.message)
                 self._diagnostics.node_status(msg,"error")
                 if log_once:
                     log_once = False
@@ -237,7 +237,7 @@ class TurtlebotNode(object):
 
     def set_operation_mode(self,req):
         if not self.robot.sci:
-            rospy.logwarn("Create : robot not connected yet, sci not available. Check if cable is connected. Incorrect TURTLEBOT_BASE environment variable causing the wrong baudrate to be used is another possible cause.")
+            rospy.logwarn("Create : robot not connected yet, sci not available. Check if cable is connected. Incorrect TURTLEBOT_BASE environment variable causing the wrong baudrate to be used is another possible cause. Ensure environment variable is set to TURTLEBOT_BASE=create for Create 1 base, TURTLEBOT_BASE=roomba for Create 2.")
             return SetTurtlebotModeResponse(False)
 
         self.operate_mode = req.mode

--- a/create_node/nodes/turtlebot_node.py
+++ b/create_node/nodes/turtlebot_node.py
@@ -325,7 +325,7 @@ class TurtlebotNode(object):
         # state
         s = self.sensor_state
         odom = Odometry(header=rospy.Header(frame_id=self.odom_frame), child_frame_id=self.base_frame)
-        js = JointState(name = ["left_wheel_joint", "right_wheel_joint", "front_castor_joint", "back_castor_joint"],
+        js = JointState(name = ["left_wheel_joint", "right_wheel_joint", "front_castor_joint", "rear_castor_joint"],
                         position=[0,0,0,0], velocity=[0,0,0,0], effort=[0,0,0,0])
 
         r = rospy.Rate(self.update_rate)


### PR DESCRIPTION
improved error handling to alert user that sci connection issues can be caused by wrong baud rate or wrong robot base type.  Users typically get a "check your cable" error and no other info. Often times the wrong robot type is causing a baudrate mismatch. For example, someone with a Create 2 using the "create" robot type will use 57600 baud rate when they should be using 115200 of the roomba.